### PR TITLE
fix(build): don't use python-semantic-release GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
     concurrency: release
     if: github.ref == 'refs/heads/main'
     needs: check
+    env:
+      GH_TOKEN: ${{ secrets.SEMANTIC_RELEASES_TOKEN }}
+      REPOSITORY_USERNAME: __token__
+      REPOSITORY_PASSWORD: ${{ secrets.PYPI_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -120,9 +124,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{env.PYTHON_LATEST}}
+      - run: python -m pip install python-semantic-release
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@master
-        with:
-          github_token: ${{ secrets.SEMANTIC_RELEASES_TOKEN }}
-          repository_username: __token__
-          repository_password: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          semantic-release publish -v DEBUG -D commit_author="github-actions <action@github.com>"


### PR DESCRIPTION
The GH action is underpinned by a Dockerfile on py39. Our min version is py310.