### PR TITLE
chore(deps): Use requirements.txt files to centralise spec of dev deps.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,16 @@ if not, [let me know!](https://github.com/topsport-com-au/starlite-saqlalchemy/i
 
 ## Workflow
 
+### Local Environment for IDE
+
+First install the library and dependencies:
+
+`poetry install`
+
+Then install test dependencies into local env for benefit of IDE:
+
+`poetry run pip install -r dev.requirements.txt`
+
 We use `pre-commit` and `tox` for code quality and testing.
 
 _Suggestion: [pipx](https://pypa.github.io/pipx/) makes installing python tools easy!_

--- a/dev.requirements.txt
+++ b/dev.requirements.txt
@@ -1,0 +1,7 @@
+coverage[toml]; python_version < '3.11'
+coverage; python_version >= '3.11'
+cryptography
+pytest
+pytest-asyncio
+pytest-dotenv
+pytest_docker

--- a/docs.requirements.txt
+++ b/docs.requirements.txt
@@ -1,0 +1,8 @@
+black
+mike
+mkdocs-gen-files
+mkdocs-literate-nav
+mkdocs-material
+mkdocs-section-index
+mkdocstrings[python]
+pymdown-extensions

--- a/tox.ini
+++ b/tox.ini
@@ -9,19 +9,14 @@ isolated_build = true
 
 [testenv]
 deps =
-    coverage[toml]
-    cryptography
-    pytest
-    pytest-asyncio
-    pytest-dotenv
-    pytest_docker
+  -r{toxinidir}/dev.requirements.txt
+
 commands =
     coverage run -p -m pytest {posargs}
 
 [testenv:coverage]
 depends = py310,py311
 basepython = python3.11
-deps = coverage[toml]
 commands =
     coverage combine
     coverage report -m --skip-covered --fail-under=85
@@ -80,13 +75,6 @@ basepython = python3.11
 passenv =
     HOME
 deps =
-    black
-    mike
-    mkdocs-gen-files
-    mkdocs-literate-nav
-    mkdocs-material
-    mkdocs-section-index
-    mkdocstrings[python]
-    pymdown-extensions
+    -r{toxinidir}/docs.requirements.txt
 commands =
     mike {posargs: serve}


### PR DESCRIPTION
There are at least two places that we want dev deps installed, tox envs,
 and in IDE environment. Same for docs deps to be consistent.

 The other way I've seen this type of thing done is multiple repeated
 declarations of all deps, or by using package extras. No one approach
 stands out to me as "best", so will trial this and see where we end up.

Closes #43 