### PR TITLE
ci(codeql): include deps on push to main.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,13 @@ jobs:
             pypi.org:443
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
-      - name: Initialize CodeQL
+      - name: Initialize CodeQL With Dependencies
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        uses: github/codeql-action/init@v2
+        with:
+          languages: python
+      - name: Initialize CodeQL Without Dependencies
+        if: github.event_name == 'pull_request'
         uses: github/codeql-action/init@v2
         with:
           languages: python


### PR DESCRIPTION
Otherwise, no deps are included.

Closes #63 