### PR TITLE
feat(app): support for using app factory.

### DIFF
--- a/src/starlite_saqlalchemy/settings.py
+++ b/src/starlite_saqlalchemy/settings.py
@@ -221,7 +221,8 @@ class ServerSettings(BaseSettings):
         env_file = ".env"
         env_prefix = "SERVER_"
 
-    APP_LOC: str = "app.main:app"
+    APP_LOC: str = "app.main:create_app"
+    APP_LOC_IS_FACTORY: bool = True
     HOST: str = "localhost"
     KEEPALIVE: int = 65
     PORT: int = 8000

--- a/tests/utils/controllers.py
+++ b/tests/utils/controllers.py
@@ -6,8 +6,7 @@ from starlite import Dependency, delete, get, post, put
 from starlite.status_codes import HTTP_200_OK
 
 from starlite_saqlalchemy.repository.types import FilterTypes
-
-from .domain import Author, CreateDTO, ReadDTO, Service, UpdateDTO
+from tests.utils.domain import Author, CreateDTO, ReadDTO, Service, UpdateDTO
 
 DETAIL_ROUTE = "/{author_id:uuid}"
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
 basepython = python3.11
 deps =
     asyncpg-stubs
-    mypy==0.982
+    mypy
     types-redis
     {[testenv]deps}
 commands =


### PR DESCRIPTION
- Changes default `APP_LOC` to `app.main:create_app`.
- Adds `APP_LOC_IS_FACTORY` config, default `True`.

Using a factory makes it a lot easier to monkeypatch configs for testing.