### PR TITLE
feat(testing): ControllerTest utility.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 exclude = alembic/*
 max-line-length = 100
-ignore = E,W,B008
+ignore = E,W,B008,PT013
 type-checking-exempt-modules = from sqlalchemy.orm
 per-file-ignores =
     examples/dto/*:T201,TC
@@ -11,6 +11,7 @@ per-file-ignores =
     src/starlite_saqlalchemy/repository/filters.py:TC
     src/starlite_saqlalchemy/scripts.py:T201
     src/starlite_saqlalchemy/settings.py:TC
+    src/starlite_saqlalchemy/testing.py:SCS108
     src/starlite_saqlalchemy/users/controllers.py:TC
     tests/*:SCS108,PT013
     tests/integration/test_tests.py:TC002,SCS108

--- a/src/starlite_saqlalchemy/testing.py
+++ b/src/starlite_saqlalchemy/testing.py
@@ -4,18 +4,25 @@ Uses a `dict` for storage.
 """
 from __future__ import annotations
 
+import random
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from uuid import uuid4
+
+from starlite.status_codes import HTTP_200_OK, HTTP_201_CREATED
 
 from starlite_saqlalchemy.db import orm
 from starlite_saqlalchemy.repository.abc import AbstractRepository
 from starlite_saqlalchemy.repository.exceptions import RepositoryConflictException
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Iterable, MutableMapping
+    from collections.abc import Callable, Hashable, Iterable, MutableMapping, Sequence
+
+    from pytest import MonkeyPatch
+    from starlite.testing import TestClient
 
     from starlite_saqlalchemy.repository.types import FilterTypes
+    from starlite_saqlalchemy.service import Service
 
 ModelT = TypeVar("ModelT", bound=orm.Base)
 MockRepoT = TypeVar("MockRepoT", bound="GenericMockRepository")
@@ -27,7 +34,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
     Uses a `dict` for storage.
     """
 
-    collection: MutableMapping[Hashable, ModelT] = {}
+    collection: MutableMapping[Hashable, ModelT]
     model_type: type[ModelT]
 
     def __init__(self, id_factory: Callable[[], Any] = uuid4, **_: Any) -> None:
@@ -169,3 +176,95 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
     def clear_collection(cls) -> None:
         """Empty the collection for repository type."""
         cls.collection = {}
+
+
+class ControllerTest:
+    """Standard controller testing utility."""
+
+    def __init__(
+        self,
+        client: TestClient,
+        base_path: str,
+        collection: Sequence[orm.Base],
+        raw_collection: Sequence[dict[str, Any]],
+        service_type: type[Service],
+        monkeypatch: MonkeyPatch,
+        collection_filters: dict[str, Any] | None = None,
+    ) -> None:
+        """Perform standard tests of controllers.
+
+        Args:
+            client: Test client instance.
+            base_path: Path for POST and collection GET requests.
+            collection: Collection of domain objects.
+            raw_collection: Collection of raw representations of domain objects.
+            service_type: The domain Service object type.
+            monkeypatch: Pytest's monkeypatch.
+            collection_filters: Collection filters for GET collection request.
+        """
+        self.client = client
+        self.base_path = base_path
+        self.collection = collection
+        self.raw_collection = raw_collection
+        self.service_type = service_type
+        self.monkeypatch = monkeypatch
+        self.collection_filters = collection_filters
+
+    def _get_random_member(self) -> Any:
+        return random.choice(self.collection)
+
+    def _get_raw_for_member(self, member: Any) -> dict[str, Any]:
+        return [item for item in self.raw_collection if item["id"] == str(member.id)][0]
+
+    def test_get_collection(self, with_filters: bool = False) -> None:
+        """Test collection endpoint get request."""
+
+        async def _list(*_: Any, **__: Any) -> list[Any]:
+            return list(self.collection)
+
+        self.monkeypatch.setattr(self.service_type, "list", _list)
+
+        resp = self.client.get(
+            self.base_path, params=self.collection_filters if with_filters else None
+        )
+
+        assert resp.status_code == HTTP_200_OK
+        assert resp.json() == self.raw_collection
+
+    def test_member_request(self, method: str, service_method: str, exp_status: int) -> None:
+        """Test member endpoint request."""
+        member = self._get_random_member()
+        raw = self._get_raw_for_member(member)
+
+        async def _method(*_: Any, **__: Any) -> Any:
+            return member
+
+        self.monkeypatch.setattr(self.service_type, service_method, _method)
+
+        if method.lower() == "post":
+            url = self.base_path
+        else:
+            url = f"{self.base_path}/{member.id}"
+
+        request_kw: dict[str, Any] = {}
+        if method.lower() in ("put", "post"):
+            request_kw["json"] = raw
+
+        resp = self.client.request(method, url, **request_kw)
+
+        assert resp.status_code == exp_status
+        assert resp.json() == raw
+
+    def run(self) -> None:
+        """Run the tests."""
+        # test the collection route with and without filters for branch coverage.
+        self.test_get_collection()
+        if self.collection_filters:
+            self.test_get_collection(with_filters=True)
+        for method, service_method, status in [
+            ("GET", "get", HTTP_200_OK),
+            ("PUT", "update", HTTP_200_OK),
+            ("POST", "create", HTTP_201_CREATED),
+            ("DELETE", "delete", HTTP_200_OK),
+        ]:
+            self.test_member_request(method, service_method, status)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 import importlib
 import sys
-from datetime import date, datetime
 from typing import TYPE_CHECKING, TypeVar
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from starlite import Starlite
@@ -14,8 +13,7 @@ from structlog.testing import CapturingLogger
 
 import starlite_saqlalchemy
 from starlite_saqlalchemy import ConfigureApp, log
-from tests.utils.domain.authors import Author
-from tests.utils.domain.books import Book
+from tests.utils.domain import authors, books
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -65,47 +63,47 @@ def fx_raw_authors() -> list[dict[str, Any]]:
 
     return [
         {
-            "id": UUID("97108ac1-ffcb-411d-8b1e-d9183399f63b"),
+            "id": "97108ac1-ffcb-411d-8b1e-d9183399f63b",
             "name": "Agatha Christie",
-            "dob": date(1890, 9, 15),
-            "created": datetime.min,
-            "updated": datetime.min,
+            "dob": "1890-09-15",
+            "created": "0001-01-01T00:00:00",
+            "updated": "0001-01-01T00:00:00",
         },
         {
-            "id": UUID("5ef29f3c-3560-4d15-ba6b-a2e5c721e4d2"),
+            "id": "5ef29f3c-3560-4d15-ba6b-a2e5c721e4d2",
             "name": "Leo Tolstoy",
-            "dob": date(1828, 9, 9),
-            "created": datetime.min,
-            "updated": datetime.min,
+            "dob": "1828-09-09",
+            "created": "0001-01-01T00:00:00",
+            "updated": "0001-01-01T00:00:00",
         },
     ]
 
 
 @pytest.fixture(name="authors")
-def fx_authors(raw_authors: list[dict[str, Any]]) -> list[Author]:
+def fx_authors(raw_authors: list[dict[str, Any]]) -> list[authors.Author]:
     """Collection of parsed Author models."""
-    return [Author(**raw) for raw in raw_authors]
+    return [authors.ReadDTO(**raw).to_mapped() for raw in raw_authors]
 
 
 @pytest.fixture(name="raw_books")
-def fx_raw_books() -> list[dict[str, Any]]:
+def fx_raw_books(raw_authors: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Unstructured book representations."""
     return [
         {
-            "id": UUID("f34545b9-663c-4fce-915d-dd1ae9cea42a"),
+            "id": "f34545b9-663c-4fce-915d-dd1ae9cea42a",
             "title": "Murder on the Orient Express",
-            "author_id": UUID("97108ac1-ffcb-411d-8b1e-d9183399f63b"),
-            "created": datetime.min,
-            "updated": datetime.min,
+            "author_id": "97108ac1-ffcb-411d-8b1e-d9183399f63b",
+            "author": raw_authors[0],
+            "created": "0001-01-01T00:00:00",
+            "updated": "0001-01-01T00:00:00",
         },
     ]
 
 
 @pytest.fixture(name="books")
-def fx_books(raw_books: list[dict[str, Any]], authors: list[Author]) -> list[Book]:
+def fx_books(raw_books: list[dict[str, Any]]) -> list[books.Book]:
     """Collection of parsed Book models."""
-    author_id_map = {author.id: author for author in authors}
-    return [Book(**raw, author=author_id_map[raw["author_id"]]) for raw in raw_books]
+    return [books.ReadDTO(**raw).to_mapped() for raw in raw_books]
 
 
 @pytest.fixture(name="create_module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from pytest_docker.plugin import Services  # type:ignore[import]
     from starlite import Starlite
 
+    from tests.utils.domain.authors import Author
+
 
 here = Path(__file__).parent
 
@@ -165,9 +167,7 @@ async def engine(docker_ip: str) -> AsyncEngine:
 
 
 @pytest.fixture(autouse=True)
-async def _seed_db(
-    engine: AsyncEngine, raw_authors: list[dict[str, Any]]
-) -> abc.AsyncIterator[None]:
+async def _seed_db(engine: AsyncEngine, authors: list[Author]) -> abc.AsyncIterator[None]:
     """Populate test database with.
 
     Args:
@@ -179,7 +179,7 @@ async def _seed_db(
     async with engine.begin() as conn:
         await conn.run_sync(metadata.create_all)
     async with engine.begin() as conn:
-        await conn.execute(author_table.insert(), raw_authors)
+        await conn.execute(author_table.insert(), [vars(item) for item in authors])
     yield
     async with engine.begin() as conn:
         await conn.run_sync(metadata.drop_all)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
-import orjson
 import pytest
 
 from starlite_saqlalchemy import db, service, worker
@@ -95,17 +94,9 @@ async def test_make_service_callback(
         {},
         service_type_id="tests.utils.domain.authors.Service",
         service_method_name="receive_callback",
-        raw_obj=orjson.loads(orjson.dumps(raw_authors[0], default=str)),
+        raw_obj=raw_authors[0],
     )
-    recv_cb_mock.assert_called_once_with(
-        raw_obj={
-            "id": "97108ac1-ffcb-411d-8b1e-d9183399f63b",
-            "name": "Agatha Christie",
-            "dob": "1890-09-15",
-            "created": "0001-01-01T00:00:00",
-            "updated": "0001-01-01T00:00:00",
-        },
-    )
+    recv_cb_mock.assert_called_once_with(raw_obj=raw_authors[0])
 
 
 async def test_make_service_callback_raises_runtime_error(
@@ -117,7 +108,7 @@ async def test_make_service_callback_raises_runtime_error(
             {},
             service_type_id="tests.utils.domain.LSKDFJ",
             service_method_name="receive_callback",
-            raw_obj=orjson.loads(orjson.dumps(raw_authors[0], default=str)),
+            raw_obj=raw_authors[0],
         )
 
 

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,11 +1,24 @@
 """Test testing module."""
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import httpx
 import pytest
+from starlite.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
 
 from starlite_saqlalchemy import testing
 from starlite_saqlalchemy.repository.exceptions import RepositoryConflictException
 from tests.utils.domain.authors import Author
+from tests.utils.domain.authors import Service as AuthorService
 from tests.utils.domain.books import Book
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from pytest import MonkeyPatch
+    from starlite import TestClient
 
 
 async def test_repo_raises_conflict_if_add_with_id(
@@ -39,3 +52,134 @@ def test_generic_mock_repository_clear_collection(
     """Test clearing collection for type."""
     author_repository_type.clear_collection()
     assert not author_repository_type.collection
+
+
+@pytest.fixture(name="mock_response")
+def fx_mock_response() -> MagicMock:
+    """Mock response for returning from mock client requests."""
+    return MagicMock(spec_set=dir(httpx.Response) + ["status_code"], status_code=HTTP_200_OK)
+
+
+@pytest.fixture(name="mock_request")
+def fx_mock_request(mock_response: MagicMock) -> MagicMock:
+    """Mock 'request' method for client."""
+    return MagicMock(return_value=mock_response)
+
+
+@pytest.fixture(name="mock_client")
+def fx_mock_client(
+    client: TestClient, mock_request: MagicMock, monkeypatch: MonkeyPatch
+) -> TestClient:
+    """Patches the test client with a mock 'request' method."""
+    monkeypatch.setattr(client, "request", mock_request)
+    return client
+
+
+@pytest.fixture(name="tester")
+def fx_tester(
+    authors: list[Author],
+    raw_authors: list[dict[str, Any]],
+    mock_client: TestClient,
+    monkeypatch: MonkeyPatch,
+    mock_response: MagicMock,
+) -> testing.ControllerTest:
+    """Tester fixture."""
+    mock_response.json.return_value = raw_authors[0]
+    return testing.ControllerTest(
+        client=mock_client,
+        base_path="/authors",
+        collection=authors[:1],
+        raw_collection=raw_authors[:1],
+        service_type=AuthorService,
+        monkeypatch=monkeypatch,
+    )
+
+
+async def test_tester_get_collection_request_service_method_patch(
+    tester: testing.ControllerTest, mock_response: MagicMock
+) -> None:
+    """Test that the "list" service method has been patched."""
+    mock_response.json.return_value = tester.raw_collection
+    tester.test_get_collection()
+    assert "<locals>._list" in str(AuthorService.list)
+    assert await AuthorService(session=None).list() == tester.collection
+
+
+def test_tester_get_collection_raises_assertion_error_on_status_code(
+    tester: testing.ControllerTest, mock_response: MagicMock
+) -> None:
+    """Test raising behavior when response status doesn't match expected."""
+    mock_response.status_code = HTTP_404_NOT_FOUND
+    with pytest.raises(AssertionError):
+        tester.test_get_collection()
+
+
+def test_tester_get_collection_raises_assertion_error_on_unexpected_json_response(
+    tester: testing.ControllerTest, mock_response: MagicMock
+) -> None:
+    """Test raising behavior when json response doesn't match expected."""
+    mock_response.json.return_value = []
+    with pytest.raises(AssertionError):
+        tester.test_get_collection()
+
+
+def test_tester_get_collection_request_called_with_query_params(
+    tester: testing.ControllerTest, mock_request: MagicMock, mock_response: MagicMock
+) -> None:
+    """Test makes request with query parameters."""
+    mock_response.json.return_value = tester.raw_collection
+    tester.collection_filters = {"a": "b"}
+    tester.test_get_collection(with_filters=True)
+    assert mock_request.mock_calls[0].kwargs["params"] == {"a": "b"}
+
+
+def test_tester_test_member_request_post_request(
+    tester: testing.ControllerTest,
+    mock_request: MagicMock,
+) -> None:
+    """Test uses correct URL for post request."""
+    tester.test_member_request("POST", "create", 200)
+    call = mock_request.mock_calls[0]
+    assert call.args[0] == "POST"
+    assert call.args[1] == "/authors"
+
+
+@pytest.mark.parametrize(("method", "service_method"), [("POST", "create"), ("PUT", "update")])
+def test_tester_json_in_request_kwargs(
+    method: str, service_method: str, tester: testing.ControllerTest, mock_request: MagicMock
+) -> None:
+    """Test adds "json" kwarg to requests for POST and PUT."""
+    tester.test_member_request(method, service_method, 200)
+    call = mock_request.mock_calls[0]
+    assert "json" in call.kwargs
+
+
+async def test_tester_member_request_service_method_patch(tester: testing.ControllerTest) -> None:
+    """Test that the appropriate service method gets patched."""
+    tester.test_member_request("GET", "get", 200)
+    assert "<locals>._method" in str(AuthorService.get)
+    assert await AuthorService(session=None).get(123) == tester.collection[0]
+
+
+@pytest.mark.parametrize("params", [{"a": "b"}, None])
+def test_tester_run_method(params: dict[str, Any] | None) -> None:
+    """Test run method makes all expected calls."""
+    self_mock = MagicMock(collection_filters=params)
+    testing.ControllerTest.run(self_mock)
+    if params:
+        assert self_mock.mock_calls == [
+            ("test_get_collection", (), {}),
+            ("test_get_collection", (), {"with_filters": True}),
+            ("test_member_request", ("GET", "get", 200), {}),
+            ("test_member_request", ("PUT", "update", 200), {}),
+            ("test_member_request", ("POST", "create", 201), {}),
+            ("test_member_request", ("DELETE", "delete", 200), {}),
+        ]
+    else:
+        assert self_mock.mock_calls == [
+            ("test_get_collection", (), {}),
+            ("test_member_request", ("GET", "get", 200), {}),
+            ("test_member_request", ("PUT", "update", 200), {}),
+            ("test_member_request", ("POST", "create", 201), {}),
+            ("test_member_request", ("DELETE", "delete", 200), {}),
+        ]


### PR DESCRIPTION
A utility for testing standard set of controllers in a standard way.

It's a starting point, there are things that will need to be improved to make it more flexible, e.g.,:

- configurable expected HTTP status for methods
- support for patch routes
- support for testing a subset of http methods
- docs