### PR TITLE
feat(repo): abstract method `filter_collection_by_kwargs()`

### DIFF
--- a/src/starlite_saqlalchemy/repository/abc.py
+++ b/src/starlite_saqlalchemy/repository/abc.py
@@ -112,6 +112,20 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
             RepositoryNotFoundException: If no instance found with same identifier as `data`.
         """
 
+    @abstractmethod
+    def filter_collection_by_kwargs(self, **kwargs: Any) -> None:
+        """Filter the collection by kwargs.
+
+        Has `AND` semantics where multiple kwargs name/value pairs are provided.
+
+        Args:
+            **kwargs: key/value pairs such that objects remaining in the collection after filtering
+                have the property that their attribute named `key` has value equal to `value`.
+
+        Raises:
+            RepositoryException: if a named attribute doesn't exist on `self.model_type`.
+        """
+
     @staticmethod
     def check_not_found(item_or_none: T | None) -> T:
         """Raise `RepositoryNotFoundException` if `item_or_none` is `None`.

--- a/src/starlite_saqlalchemy/repository/sqlalchemy.py
+++ b/src/starlite_saqlalchemy/repository/sqlalchemy.py
@@ -206,6 +206,16 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
             self.session.expunge(instance)
             return instance
 
+    def filter_collection_by_kwargs(self, **kwargs: Any) -> None:
+        """Filter the collection by kwargs.
+
+        Args:
+            **kwargs: key/value pairs such that objects remaining in the collection after filtering
+                have the property that their attribute named `key` has value equal to `value`.
+        """
+        with wrap_sqlalchemy_exception():
+            self._select.filter_by(**kwargs)
+
     @classmethod
     async def check_health(cls, session: AsyncSession) -> bool:
         """Perform a health check on the database.

--- a/tests/integration/repository/test_sqlalchemy_repository.py
+++ b/tests/integration/repository/test_sqlalchemy_repository.py
@@ -1,0 +1,20 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from starlite_saqlalchemy.repository.exceptions import RepositoryException
+from tests.utils.domain import authors
+
+
+@pytest.fixture(name="session")
+def fx_session(engine: AsyncEngine) -> AsyncSession:
+    return async_sessionmaker(bind=engine)()
+
+
+@pytest.fixture(name="repo")
+def fx_repo(session: AsyncSession) -> authors.Repository:
+    return authors.Repository(session=session)
+
+
+def test_filter_by_kwargs_with_incorrect_attribute_name(repo: authors.Repository) -> None:
+    with pytest.raises(RepositoryException):
+        repo.filter_collection_by_kwargs(whoops="silly me")

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -9,7 +9,10 @@ import pytest
 from starlite.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
 
 from starlite_saqlalchemy import testing
-from starlite_saqlalchemy.repository.exceptions import RepositoryConflictException
+from starlite_saqlalchemy.repository.exceptions import (
+    RepositoryConflictException,
+    RepositoryException,
+)
 from tests.utils.domain.authors import Author
 from tests.utils.domain.authors import Service as AuthorService
 from tests.utils.domain.books import Book
@@ -52,6 +55,33 @@ def test_generic_mock_repository_clear_collection(
     """Test clearing collection for type."""
     author_repository_type.clear_collection()
     assert not author_repository_type.collection
+
+
+def test_generic_mock_repository_filter_collection_by_kwargs(
+    author_repository: testing.GenericMockRepository[Author],
+) -> None:
+    """Test filtering the repository collection by kwargs."""
+    author_repository.filter_collection_by_kwargs(name="Leo Tolstoy")
+    assert len(author_repository.collection) == 1
+    assert list(author_repository.collection.values())[0].name == "Leo Tolstoy"
+
+
+def test_generic_mock_repository_filter_collection_by_kwargs_and_semantics(
+    author_repository: testing.GenericMockRepository[Author],
+) -> None:
+    """Test that filtering by kwargs has `AND` semantics when multiple kwargs,
+    not `OR`."""
+    author_repository.filter_collection_by_kwargs(name="Agatha Christie", dob="1828-09-09")
+    assert len(author_repository.collection) == 0
+
+
+def test_generic_mock_repository_raises_repository_exception_if_named_attribute_doesnt_exist(
+    author_repository: testing.GenericMockRepository[Author],
+) -> None:
+    """Test that a repo exception is raised if a named attribute doesn't
+    exist."""
+    with pytest.raises(RepositoryException):
+        author_repository.filter_collection_by_kwargs(cricket="ball")
 
 
 @pytest.fixture(name="mock_response")


### PR DESCRIPTION
Method filters the collection to items that have attributes with values equal to kwargs passed to method.

Has AND semantics, so multiple kwargs means items must have equal values for all to remain in the collection.

Raises RepositoryException if an incorrect attribute is given.

Closes #158 