### PR TITLE
feat!: follow starlite into msgspec.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -188,17 +188,17 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "msgspec"
+version = "0.10.1"
+description = "A fast and friendly JSON/MessagePack library, with optional schema validation"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[[package]]
 name = "multidict"
 version = "6.0.3"
 description = "multidict implementation"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[[package]]
-name = "orjson"
-version = "3.8.3"
-description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 category = "main"
 optional = false
 python-versions = ">=3.7"
@@ -382,7 +382,7 @@ typing-extensions = ">=4.2.0"
 
 [package.extras]
 aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
-aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing-extensions (!=3.10.0.1)"]
+aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
 asyncmy = ["asyncmy (>=0.2.3,!=0.2.4)", "greenlet (!=0.4.17)"]
 mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5)"]
@@ -392,7 +392,7 @@ mssql-pyodbc = ["pyodbc"]
 mypy = ["mypy (>=0.910)"]
 mysql = ["mysqlclient (>=1.4.0)"]
 mysql-connector = ["mysql-connector-python"]
-oracle = ["cx-oracle (>=7)"]
+oracle = ["cx_oracle (>=7)"]
 oracle-oracledb = ["oracledb (>=1.0.1)"]
 postgresql = ["psycopg2 (>=2.7)"]
 postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
@@ -401,11 +401,11 @@ postgresql-psycopg = ["psycopg (>=3.0.7)"]
 postgresql-psycopg2binary = ["psycopg2-binary"]
 postgresql-psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql"]
-sqlcipher = ["sqlcipher3-binary"]
+sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "starlite"
-version = "1.44.0"
+version = "1.45.0"
 description = "Performant, light and flexible ASGI API Framework"
 category = "main"
 optional = false
@@ -414,8 +414,8 @@ python-versions = ">=3.8,<4.0"
 [package.dependencies]
 anyio = ">=3"
 httpx = ">=0.22"
+msgspec = ">=0.10.1"
 multidict = ">=6.0.2"
-orjson = "*"
 pydantic = "*"
 pydantic-factories = "*"
 pydantic-openapi-schema = "*"
@@ -499,7 +499,7 @@ test = ["Cython (>=0.29.32,<0.30.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "my
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "73bc63c63e58f6d307934093a96b9c3c0818b274aca6453db4570ca48d092da1"
+content-hash = "e039848ab9cd9287c07bbf69220e2fe9963a91a51ba1f69b8c04193577992708"
 
 [metadata.files]
 anyio = [
@@ -697,6 +697,37 @@ idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
+msgspec = [
+    {file = "msgspec-0.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c5d0db7a52a5b41337b57f82c55aeb0e9ddeb5d568e2e059009fbc1b60b4ac99"},
+    {file = "msgspec-0.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:72d4056fbb75cd6a51da86f6ca9d39bd67163b6d04c9fe0f3e331d814f651512"},
+    {file = "msgspec-0.10.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aee4810f8411a285675d6bced87ed5fd59a58792cf223f0591a3c911b3aa4fd6"},
+    {file = "msgspec-0.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa5c15d8d5c36a1a47dc85df5b74fe8f1a6c97c57de7cc065bceeb53d0468f10"},
+    {file = "msgspec-0.10.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:970b1b8d4fb3a474b5b003b48c181b385c23bb263f0906cda731a6f12070b9b2"},
+    {file = "msgspec-0.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:636f6a0480a05f5be2b184f826bbbc15a90cf5e22b78a204408fa3ad92d6c96f"},
+    {file = "msgspec-0.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:750c1374b8129f5793cfea5fef069b6be69ee6f3e6e4b1a202e1b16e1d126dd4"},
+    {file = "msgspec-0.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a732a442ff7c943f9341191a89ce8938f27e96d53ace87502c5dcf6c4614bc8a"},
+    {file = "msgspec-0.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:22920e23e57b1db92171aa52a785e47a04f5a21a84cf92caf7ad78c9200ddd06"},
+    {file = "msgspec-0.10.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4cb25d51cb9708a324c8b53daf6ca2d91fcfd7c51c3441fdfb6b36562a8624e"},
+    {file = "msgspec-0.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c1f6cd279ef1e4fb78844924f28676a78bb64da4da01c320740c5a65d3b2b91"},
+    {file = "msgspec-0.10.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8d327f518db0aa24b28624fed1a8ae4b02fede568e57055f70afd93b82b96f15"},
+    {file = "msgspec-0.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:79c79fbc37dde6d2a2e73160ee3ba6d3d03041395ee6748e4feff2f13766a1c5"},
+    {file = "msgspec-0.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:930b2f676075a864ae7bb4cdfb7b6deeb575d19fe668a09854c026bda80c710d"},
+    {file = "msgspec-0.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:99b7e5ef0c0f0e5134d57f3e5b5eb4513b479cc1e32a3191377f6d9ed957c20d"},
+    {file = "msgspec-0.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ad77924223829bc4b7b2373999b8553bf2701e566d1e7c47d8c5646a399525fc"},
+    {file = "msgspec-0.10.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4de6b43ae27c3ba5176b5f58c6d3f2d51217b57678de3c4faafc25dae49dba7"},
+    {file = "msgspec-0.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf134628bf5968c479d158e49d88a09a5302a56d9934ce2cc98f9d17ad306ad6"},
+    {file = "msgspec-0.10.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:33d09e754baaa4062bdc82c4638d81675e06dd00bbf971f28d8684be87924943"},
+    {file = "msgspec-0.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:34d149c24fb926e3b138bf69bdbec517e9c49356412ccd03642e4a10f67e2f05"},
+    {file = "msgspec-0.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:4ad2bcd58a235303a37271851d4933c8e99068d1c5c102409ccf096918fe8a3b"},
+    {file = "msgspec-0.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3cdf4eb3b81e20672fa55d7a8dcadac6ec175fcabef1f7f5670fbe1ebe5e0cc0"},
+    {file = "msgspec-0.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:67c64bc237f656a7f2990aa38339bdc72314ab0c480bb267e1fd1d7a5a09a147"},
+    {file = "msgspec-0.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5401253669343f1e6325e88165d51b4a32a8727718fc0f34ed7583f2022ed64a"},
+    {file = "msgspec-0.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96576b8ec6e52efa5dd835a229c1ddffd0557746b814e83c04b679c3de6bb7d3"},
+    {file = "msgspec-0.10.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2eeaf8dea776eb0cecd28f83e9029ecc754bc7cf37de6b43a628d5f8fc1c921e"},
+    {file = "msgspec-0.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:970407e05ac9c59e90791befa23decd4ef4cc4b3b6b7bb1a6797ba5d3f64625d"},
+    {file = "msgspec-0.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:e6244009afdf5083ccfcf6038de8fb4a1d94254e4716b402d478e0275f431e8f"},
+    {file = "msgspec-0.10.1.tar.gz", hash = "sha256:770c29c5bf227f1c5e3bd0f82ecea313b74772763997c2a5d0ff1375c7e4e1db"},
+]
 multidict = [
     {file = "multidict-6.0.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:73009ea04205966d47e16d98686ac5c438af23a1bb30b48a2c5da3423ec9ce37"},
     {file = "multidict-6.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8b92a9f3ab904397a33b193000dc4de7318ea175c4c460a1e154c415f9008e3d"},
@@ -772,52 +803,6 @@ multidict = [
     {file = "multidict-6.0.3-cp39-cp39-win32.whl", hash = "sha256:018c8e3be7f161a12b3e41741b6721f9baeb2210f4ab25a6359b7d76c1017dce"},
     {file = "multidict-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:5e58ec0375803526d395f6f7e730ecc45d06e15f68f7b9cdbf644a2918324e51"},
     {file = "multidict-6.0.3.tar.gz", hash = "sha256:2523a29006c034687eccd3ee70093a697129a3ffe8732535d3b2df6a4ecc279d"},
-]
-orjson = [
-    {file = "orjson-3.8.3-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:6bf425bba42a8cee49d611ddd50b7fea9e87787e77bf90b2cb9742293f319480"},
-    {file = "orjson-3.8.3-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:068febdc7e10655a68a381d2db714d0a90ce46dc81519a4962521a0af07697fb"},
-    {file = "orjson-3.8.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d46241e63df2d39f4b7d44e2ff2becfb6646052b963afb1a99f4ef8c2a31aba0"},
-    {file = "orjson-3.8.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:961bc1dcbc3a89b52e8979194b3043e7d28ffc979187e46ad23efa8ada612d04"},
-    {file = "orjson-3.8.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65ea3336c2bda31bc938785b84283118dec52eb90a2946b140054873946f60a4"},
-    {file = "orjson-3.8.3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:83891e9c3a172841f63cae75ff9ce78f12e4c2c5161baec7af725b1d71d4de21"},
-    {file = "orjson-3.8.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4b587ec06ab7dd4fb5acf50af98314487b7d56d6e1a7f05d49d8367e0e0b23bc"},
-    {file = "orjson-3.8.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:37196a7f2219508c6d944d7d5ea0000a226818787dadbbed309bfa6174f0402b"},
-    {file = "orjson-3.8.3-cp310-none-win_amd64.whl", hash = "sha256:94bd4295fadea984b6284dc55f7d1ea828240057f3b6a1d8ec3fe4d1ea596964"},
-    {file = "orjson-3.8.3-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:8fe6188ea2a1165280b4ff5fab92753b2007665804e8214be3d00d0b83b5764e"},
-    {file = "orjson-3.8.3-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:d30d427a1a731157206ddb1e95620925298e4c7c3f93838f53bd19f6069be244"},
-    {file = "orjson-3.8.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3497dde5c99dd616554f0dcb694b955a2dc3eb920fe36b150f88ce53e3be2a46"},
-    {file = "orjson-3.8.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dc29ff612030f3c2e8d7c0bc6c74d18b76dde3726230d892524735498f29f4b2"},
-    {file = "orjson-3.8.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1612e08b8254d359f9b72c4a4099d46cdc0f58b574da48472625a0e80222b6e"},
-    {file = "orjson-3.8.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:54f3ef512876199d7dacd348a0fc53392c6be15bdf857b2d67fa1b089d561b98"},
-    {file = "orjson-3.8.3-cp311-none-win_amd64.whl", hash = "sha256:a30503ee24fc3c59f768501d7a7ded5119a631c79033929a5035a4c91901eac7"},
-    {file = "orjson-3.8.3-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:d746da1260bbe7cb06200813cc40482fb1b0595c4c09c3afffe34cfc408d0a4a"},
-    {file = "orjson-3.8.3-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:e570fdfa09b84cc7c42a3a6dd22dbd2177cb5f3798feefc430066b260886acae"},
-    {file = "orjson-3.8.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca61e6c5a86efb49b790c8e331ff05db6d5ed773dfc9b58667ea3b260971cfb2"},
-    {file = "orjson-3.8.3-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4cd0bb7e843ceba759e4d4cc2ca9243d1a878dac42cdcfc2295883fbd5bd2400"},
-    {file = "orjson-3.8.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff96c61127550ae25caab325e1f4a4fba2740ca77f8e81640f1b8b575e95f784"},
-    {file = "orjson-3.8.3-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:faf44a709f54cf490a27ccb0fb1cb5a99005c36ff7cb127d222306bf84f5493f"},
-    {file = "orjson-3.8.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:194aef99db88b450b0005406f259ad07df545e6c9632f2a64c04986a0faf2c68"},
-    {file = "orjson-3.8.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:aa57fe8b32750a64c816840444ec4d1e4310630ecd9d1d7b3db4b45d248b5585"},
-    {file = "orjson-3.8.3-cp37-none-win_amd64.whl", hash = "sha256:dbd74d2d3d0b7ac8ca968c3be51d4cfbecec65c6d6f55dabe95e975c234d0338"},
-    {file = "orjson-3.8.3-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:ef3b4c7931989eb973fbbcc38accf7711d607a2b0ed84817341878ec8effb9c5"},
-    {file = "orjson-3.8.3-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:cf3dad7dbf65f78fefca0eb385d606844ea58a64fe908883a32768dfaee0b952"},
-    {file = "orjson-3.8.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbdfbd49d58cbaabfa88fcdf9e4f09487acca3d17f144648668ea6ae06cc3183"},
-    {file = "orjson-3.8.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f06ef273d8d4101948ebc4262a485737bcfd440fb83dd4b125d3e5f4226117bc"},
-    {file = "orjson-3.8.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75de90c34db99c42ee7608ff88320442d3ce17c258203139b5a8b0afb4a9b43b"},
-    {file = "orjson-3.8.3-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:78d69020fa9cf28b363d2494e5f1f10210e8fecf49bf4a767fcffcce7b9d7f58"},
-    {file = "orjson-3.8.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b70782258c73913eb6542c04b6556c841247eb92eeace5db2ee2e1d4cb6ffaa5"},
-    {file = "orjson-3.8.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:989bf5980fc8aca43a9d0a50ea0a0eee81257e812aaceb1e9c0dbd0856fc5230"},
-    {file = "orjson-3.8.3-cp38-none-win_amd64.whl", hash = "sha256:52540572c349179e2a7b6a7b98d6e9320e0333533af809359a95f7b57a61c506"},
-    {file = "orjson-3.8.3-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:7f0ec0ca4e81492569057199e042607090ba48289c4f59f29bbc219282b8dc60"},
-    {file = "orjson-3.8.3-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:b7018494a7a11bcd04da1173c3a38fa5a866f905c138326504552231824ac9c1"},
-    {file = "orjson-3.8.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5870ced447a9fbeb5aeb90f362d9106b80a32f729a57b59c64684dbc9175e92"},
-    {file = "orjson-3.8.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0459893746dc80dbfb262a24c08fdba2a737d44d26691e85f27b2223cac8075f"},
-    {file = "orjson-3.8.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0379ad4c0246281f136a93ed357e342f24070c7055f00aeff9a69c2352e38d10"},
-    {file = "orjson-3.8.3-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:3e9e54ff8c9253d7f01ebc5836a1308d0ebe8e5c2edee620867a49556a158484"},
-    {file = "orjson-3.8.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f8ff793a3188c21e646219dc5e2c60a74dde25c26de3075f4c2e33cf25835340"},
-    {file = "orjson-3.8.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b0c13e05da5bc1a6b2e1d3b117cc669e2267ce0a131e94845056d506ef041c6"},
-    {file = "orjson-3.8.3-cp39-none-win_amd64.whl", hash = "sha256:4fff44ca121329d62e48582850a247a487e968cfccd5527fab20bd5b650b78c3"},
-    {file = "orjson-3.8.3.tar.gz", hash = "sha256:eda1534a5289168614f21422861cbfb1abb8a82d66c00a8ba823d863c0797178"},
 ]
 pydantic = [
     {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
@@ -940,51 +925,11 @@ sniffio = [
     {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-2.0.0b4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:47676ec13cd42affb087536e7445440e1f1c5445214496c2155bcba1c2493200"},
-    {file = "SQLAlchemy-2.0.0b4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7c53cdf387bb9c52601e4266b47f8fda4c8cffbdb4169eccf50cc750e6f80d29"},
-    {file = "SQLAlchemy-2.0.0b4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf6326ed3f973cb28271d3366fec7db18f3639f005f3febf4c1ec64c71404954"},
-    {file = "SQLAlchemy-2.0.0b4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e572557e2f6ce617c3354e69e3f20772a6d1fa9375fb0a3a6559050f27c6f2b7"},
-    {file = "SQLAlchemy-2.0.0b4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:38fe1e92798b6fd34891b86094814c6aeed81e2b4b1ee3311d5e85b1ba0c5dea"},
-    {file = "SQLAlchemy-2.0.0b4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:93ce5c23971ec0a021fd0aaab96be73053f2f7226849f1dd4b25e933a2493831"},
-    {file = "SQLAlchemy-2.0.0b4-cp310-cp310-win32.whl", hash = "sha256:c2ee253256330e9a6aed62c119b11ebbe7d65efe3e83cd8c43c35c719c1cfb83"},
-    {file = "SQLAlchemy-2.0.0b4-cp310-cp310-win_amd64.whl", hash = "sha256:343999f56ac5adf90c9e9b005470291862188308e49d51e453605f30b172938c"},
-    {file = "SQLAlchemy-2.0.0b4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:02eb8f9519c7b91c34b169e2bd97c30dca215826710d6be784e54995d999cc3d"},
-    {file = "SQLAlchemy-2.0.0b4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0c60418ed2b9f27b4f47766994d5cfc43c812eb62e146660daf454965bd7a0b3"},
-    {file = "SQLAlchemy-2.0.0b4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:541caec6f148b8d8410adcc1d0db5cc24d39995446db237d390882bb9f256c5f"},
-    {file = "SQLAlchemy-2.0.0b4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17fad5ba55f92fd1646aa7d97f96b635d50051ce33791e53d39b5310f87f189f"},
-    {file = "SQLAlchemy-2.0.0b4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fb8d24020f7ae5f1b08f222eacd09643b7c63a0b385c64333a41e177351f12c"},
-    {file = "SQLAlchemy-2.0.0b4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f28ee1d4ada7493e1128f8ee9c2b0cacef19ca3d4b6ab52d6858eb9201fc71c5"},
-    {file = "SQLAlchemy-2.0.0b4-cp311-cp311-win32.whl", hash = "sha256:a0661809504c2d4339f5f2fd5170537f43b2bdde71fa29e87bd9905a2cb5d490"},
-    {file = "SQLAlchemy-2.0.0b4-cp311-cp311-win_amd64.whl", hash = "sha256:40a166b7820b13667d72adaa46575bfb04f6dd417a1a07289fa7e94cdb2fb838"},
-    {file = "SQLAlchemy-2.0.0b4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0133394aec83d88e65aee7e4e665223b0b96e5aac4ecf060475e0d3bb38e7e55"},
-    {file = "SQLAlchemy-2.0.0b4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccdcf866f4cab9487a845cb3ab7f6b3d81539af146481e9dd1a5c77c85a82d6a"},
-    {file = "SQLAlchemy-2.0.0b4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93457c593bb74d4cc5982a6f2b5f2719033232dd219f807caf5524419ae22981"},
-    {file = "SQLAlchemy-2.0.0b4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5bf749cb1bf707d5d9f8af78c4ebfd3b1e2e69eab46ab6f74a22720792302481"},
-    {file = "SQLAlchemy-2.0.0b4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4ed849702dd83f7db68b4380aa13cc9739b4656f13cb7de4e3a9f5884c92e0f7"},
-    {file = "SQLAlchemy-2.0.0b4-cp37-cp37m-win32.whl", hash = "sha256:1d08d4e48564b732f7372a2fce52bbdd558ae54b578a08648b5b27429582cc20"},
-    {file = "SQLAlchemy-2.0.0b4-cp37-cp37m-win_amd64.whl", hash = "sha256:1e15c629b7099ffb10e8cc27456b98d5a3759b6a5b0e6fc77fc8252565641a3d"},
-    {file = "SQLAlchemy-2.0.0b4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:35bc474ca96f9b0177bb81e24024a1390d7577930fab67f276987caeb860e35d"},
-    {file = "SQLAlchemy-2.0.0b4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49656ede1328954521278a16b176cf977ba681451dab49344f596d9c697fbe02"},
-    {file = "SQLAlchemy-2.0.0b4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28104b37cafe8c5f83c0831d2e057e7043501420b8853f9a731245c60a9dfd2e"},
-    {file = "SQLAlchemy-2.0.0b4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e8714aba7cd67b09f0c249e03fd1e244113e37f0e3320393f5d8a9574aeedc8"},
-    {file = "SQLAlchemy-2.0.0b4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:a37a7a4cea0dced9640b64a092380b811b1670b664ac95115e85536ff8cbae36"},
-    {file = "SQLAlchemy-2.0.0b4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:dfb3aba32cc442324d29e293b2dfae2d5931ae9ca0a733d2cb9064190b14451b"},
-    {file = "SQLAlchemy-2.0.0b4-cp38-cp38-win32.whl", hash = "sha256:f755808766fe3084dbf6907da03182c4ad848ea36906a06f2ee2a6e06dfcc0b7"},
-    {file = "SQLAlchemy-2.0.0b4-cp38-cp38-win_amd64.whl", hash = "sha256:dc34366c5c802836b0160c087a6cf8dbbed810654fde1b7d4fa19a9c93ac179d"},
-    {file = "SQLAlchemy-2.0.0b4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0ab88dfd38bfd05b9c5e7ca685c4a41bc7a2ec7cd263e199679903d41ea0b08c"},
-    {file = "SQLAlchemy-2.0.0b4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fa434058577de8b2fa3f710afa147cbecc45929216e78802215bdd515a98e4de"},
-    {file = "SQLAlchemy-2.0.0b4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29bb560d8c4a53816d271275c1f76055c8aafe1a7c7582b0fe6f3de93feb26d0"},
-    {file = "SQLAlchemy-2.0.0b4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f640d189c9a462550d6c6e1b23a29f98db0c7d2eb283867e28a22a9177d92d5"},
-    {file = "SQLAlchemy-2.0.0b4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:86165070c4d0fa0d3a4fe57879ffc817d75cff23f73cf1f8f6fabaee31cb9b5c"},
-    {file = "SQLAlchemy-2.0.0b4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:57f405fe44cd3a7785a014c62369df138ea95dd3b2887090aad9b24ea093f6e6"},
-    {file = "SQLAlchemy-2.0.0b4-cp39-cp39-win32.whl", hash = "sha256:0ff16ff5e943cdbd65242756d430df4c98bd9296f78fcf6e30eb8bee62d13ec2"},
-    {file = "SQLAlchemy-2.0.0b4-cp39-cp39-win_amd64.whl", hash = "sha256:07e12e63e98f34a1f529adc8931f7909148aca9809686e922f782f54e9d194fa"},
-    {file = "SQLAlchemy-2.0.0b4-py3-none-any.whl", hash = "sha256:68a584e37b2b582047ebf60d0975ef8f6f80cffa6221a392a73ee9bc46fa7c7e"},
     {file = "SQLAlchemy-2.0.0b4.tar.gz", hash = "sha256:3192d9af656d0fc1b07351f0ac13a84bb679f40f918234e54cbcc36af11766fe"},
 ]
 starlite = [
-    {file = "starlite-1.44.0-py3-none-any.whl", hash = "sha256:2a9a32733e38382942709e84955a137841ecd339953a4224928d7da4cbb8297a"},
-    {file = "starlite-1.44.0.tar.gz", hash = "sha256:eee794f06024255843ef7a589081da3e184843c5569781fac7c1c5e20a3c33a1"},
+    {file = "starlite-1.45.0-py3-none-any.whl", hash = "sha256:a01065f4117c4551a482fa6e4805d029fd591a0ed5044bcf0885c9285b882111"},
+    {file = "starlite-1.45.0.tar.gz", hash = "sha256:af180cebcc40549effefee791b926f04f5c19b50facf2d54ae84e51a77aa9fc2"},
 ]
 structlog = [
     {file = "structlog-22.3.0-py3-none-any.whl", hash = "sha256:b403f344f902b220648fa9f286a23c0cc5439a5844d271fec40562dbadbc70ad"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ python = "^3.10"
 asyncpg = "*"
 hiredis = "*"
 httpx = "*"
-orjson = "*"
+msgspec = "*"
 pydantic = "*"
 python-dotenv = "*"
 redis = "*"
@@ -95,7 +95,7 @@ disable = [
     "too-many-arguments",
 ]
 enable = "useless-suppression"
-extension-pkg-whitelist = ["asyncpg", "orjson", "pydantic"]
+extension-pkg-whitelist = ["asyncpg", "msgspec", "pydantic"]
 
 [tool.semantic_release]
 branch = "main"

--- a/src/starlite_saqlalchemy/db/__init__.py
+++ b/src/starlite_saqlalchemy/db/__init__.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from functools import partial
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from orjson import dumps, loads
+import msgspec
 from sqlalchemy import event
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
@@ -27,18 +26,20 @@ def _default(val: Any) -> str:
     raise TypeError()
 
 
+_msgspec_json_encoder = msgspec.json.Encoder(enc_hook=_default)
+
 engine = create_async_engine(
     settings.db.URL,
     echo=settings.db.ECHO,
     echo_pool=settings.db.ECHO_POOL,
-    json_serializer=partial(dumps, default=_default),
+    json_serializer=_msgspec_json_encoder.encode,
     max_overflow=settings.db.POOL_MAX_OVERFLOW,
     pool_size=settings.db.POOL_SIZE,
     pool_timeout=settings.db.POOL_TIMEOUT,
     poolclass=NullPool if settings.db.POOL_DISABLE else None,
 )
 """Configure via [DatabaseSettings][starlite_saqlalchemy.settings.DatabaseSettings]. Overrides
-default JSON serializer to use `orjson`. See
+default JSON serializer to use `msgspec`. See
 [`create_async_engine()`][sqlalchemy.ext.asyncio.create_async_engine] for detailed instructions.
 """
 async_session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(engine)
@@ -49,12 +50,11 @@ Database session factory. See [`async_sessionmaker()`][sqlalchemy.ext.asyncio.as
 
 @event.listens_for(engine.sync_engine, "connect")
 def _sqla_on_connect(dbapi_connection: Any, _: Any) -> Any:  # pragma: no cover
-    """Handle orjson binary output.
+    """Handle msgspec binary output.
 
     SQLAlchemy expects that the json serializer returns `str` and calls `.encode()` on the value to
-    turn it to bytes before writing to the JSONB column. I'd need to either wrap `orjson.dumps` to
-    return a `str` so that SQLAlchemy could then convert it to binary, or do the following, which
-    changes the behaviour of the dialect to expect a binary value from the serializer.
+    turn it to bytes before writing to the JSONB column. This changes the behaviour of the dialect
+    to expect a binary value from the serializer.
 
     See Also https://github.com/sqlalchemy/sqlalchemy/blob/14bfbadfdf9260a1c40f63b31641b27fe9de12a0/lib/sqlalchemy/dialects/postgresql/asyncpg.py#L934  pylint: disable=line-too-long
     """
@@ -67,7 +67,7 @@ def _sqla_on_connect(dbapi_connection: Any, _: Any) -> Any:  # pragma: no cover
     def decoder(bin_value: bytes) -> Any:
         # the byte is the \x01 prefix for jsonb used by PostgreSQL.
         # asyncpg returns it when format='binary'
-        return loads(bin_value[1:])
+        return msgspec.json.decode(bin_value[1:])
 
     dbapi_connection.await_(
         dbapi_connection.driver_connection.set_type_codec(

--- a/src/starlite_saqlalchemy/log/__init__.py
+++ b/src/starlite_saqlalchemy/log/__init__.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from typing import TYPE_CHECKING
 
-import orjson
+import msgspec
 import structlog
 from starlite.config.logging import LoggingConfig
 
@@ -43,7 +43,7 @@ else:  # pragma: no cover
     default_processors.extend(
         [
             structlog.processors.dict_tracebacks,
-            structlog.processors.JSONRenderer(serializer=orjson.dumps),
+            structlog.processors.JSONRenderer(serializer=msgspec.json.encode),
         ]
     )
 

--- a/src/starlite_saqlalchemy/worker.py
+++ b/src/starlite_saqlalchemy/worker.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 import asyncio
-from functools import partial
 from typing import TYPE_CHECKING, Any
 
-import orjson
+import msgspec
 import saq
 
 from starlite_saqlalchemy import redis, settings
@@ -37,8 +36,8 @@ class Queue(saq.Queue):
             **kwargs: Passed through to `saq.Queue.__init__()`
         """
         kwargs.setdefault("name", settings.app.slug)
-        kwargs.setdefault("dump", partial(orjson.dumps, default=str))
-        kwargs.setdefault("load", orjson.loads)
+        kwargs.setdefault("dump", msgspec.json.encode)
+        kwargs.setdefault("load", msgspec.json.decode)
         super().__init__(*args, **kwargs)
 
 

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -42,7 +42,7 @@ async def test_logging(app: "Starlite", cap_logger: CapturingLogger) -> None:
                 "response": {
                     "status_code": 200,
                     "cookies": {},
-                    "headers": {"content-type": "application/json", "content-length": "144"},
+                    "headers": {"content-type": "application/json", "content-length": "151"},
                     "body": ANY,
                 },
                 "request": {


### PR DESCRIPTION
Replaces any use of `orjson` with `msgspec` equivalent.