### PR TITLE
feat!(service): Adds `service.RepositoryService` type.

### DIFF
--- a/docs/async_worker.md
+++ b/docs/async_worker.md
@@ -28,7 +28,7 @@ class Repository(SQLAlchemyRepository[Author]):
     model_type = Author
 
 
-class Service(service.Service[Author]):
+class Service(service.RepositoryService[Author]):
     """Author service object."""
 
     repository_type = Repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ skip_covered = true
 exclude_lines = [
     'if TYPE_CHECKING:',
     'pragma: no cover',
+    'raise NotImplementedError',
 ]
 
 [tool.isort]

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -124,3 +124,9 @@ async def test_enqueue_service_callback(monkeypatch: "MonkeyPatch") -> None:
         service_method_name="receive_callback",
         raw_obj={"a": "b"},
     )
+
+
+async def test_service_new_context_manager() -> None:
+    """Simple test of `Service.new()` context manager behavior."""
+    async with service.Service[domain.authors.Author].new() as service_obj:
+        assert isinstance(service_obj, service.Service)

--- a/tests/utils/domain/authors.py
+++ b/tests/utils/domain/authors.py
@@ -22,7 +22,7 @@ class Repository(repository.sqlalchemy.SQLAlchemyRepository[Author]):
     model_type = Author
 
 
-class Service(service.Service[Author]):
+class Service(service.RepositoryService[Author]):
     """Author service object."""
 
     repository_type = Repository

--- a/tests/utils/domain/books.py
+++ b/tests/utils/domain/books.py
@@ -28,7 +28,7 @@ class Repository(SQLAlchemyRepository[Book]):
     model_type = Book
 
 
-class Service(service.Service[Book]):
+class Service(service.RepositoryService[Book]):
     """Book service."""
 
     repository_type = Repository


### PR DESCRIPTION
The coupling between the base service object and a repository type was too inflexible to be useful when building an app that doesn't need a repository.

`service.Service` is no longer aware of `repository_type` and has no default implementations defined.

To get the same behavior as previous versions, service objects should now inherit from `service.RepositoryService`.

This is for #170, but #170 is broader than this change. We still need to make the repository service not _need_ to use SQLAlchemy ORM types as the model type.