### PR TITLE
feat(worker): Allow multiple queues per worker configuration

### DIFF
--- a/src/starlite_saqlalchemy/worker.py
+++ b/src/starlite_saqlalchemy/worker.py
@@ -53,7 +53,14 @@ class Queue(saq.Queue):
         super().__init__(*args, **kwargs)
 
     def namespace(self, key: str) -> str:
-        """Makes the namespace unique per app."""
+        """Namespace for the Queue.
+
+        Args:
+            key (str): The unique key to use for the namespace.
+
+        Returns:
+            str: The worker namespace
+        """
         return f"{settings.app.slug}:{self.name}:{key}"
 
 

--- a/src/starlite_saqlalchemy/worker.py
+++ b/src/starlite_saqlalchemy/worker.py
@@ -47,10 +47,14 @@ class Queue(saq.Queue):
             *args: Passed through to `saq.Queue.__init__()`
             **kwargs: Passed through to `saq.Queue.__init__()`
         """
-        kwargs.setdefault("name", settings.app.slug)
+        kwargs.setdefault("name", "background-worker")
         kwargs.setdefault("dump", encoder.encode)
         kwargs.setdefault("load", msgspec.json.decode)
         super().__init__(*args, **kwargs)
+
+    def namespace(self, key: str) -> str:
+        """Makes the namespace unique per app."""
+        return f"{settings.app.slug}:{self.name}:{key}"
 
 
 class Worker(saq.Worker):
@@ -63,6 +67,7 @@ class Worker(saq.Worker):
         """Attach the worker to the running event loop."""
         loop = asyncio.get_running_loop()
         loop.create_task(self.start())
+
 
 
 queue = Queue(redis.client)

--- a/src/starlite_saqlalchemy/worker.py
+++ b/src/starlite_saqlalchemy/worker.py
@@ -69,7 +69,6 @@ class Worker(saq.Worker):
         loop.create_task(self.start())
 
 
-
 queue = Queue(redis.client)
 """Async worker queue.
 


### PR DESCRIPTION
Take a look at this enhancement.  This change allows for you to run multiple queues for a given worker application.  

In my use case, I run multiple SAQ workers as a component of an "Agent" daemon that runs on groups of servers.  Each API process can service multiple groups of the agent workers.  This allows me to send tasks to particular groups of workers or create a "high priority" worker queue in addition to the default.
