### PR TITLE
feat(health): Custom health checks

### DIFF
--- a/src/starlite_saqlalchemy/exceptions.py
+++ b/src/starlite_saqlalchemy/exceptions.py
@@ -51,6 +51,10 @@ class AuthorizationError(StarliteSaqlalchemyError):
     """A user tried to do something they shouldn't have."""
 
 
+class HealthCheckConfigurationError(StarliteSaqlalchemyError):
+    """An error occurred while registering an health check."""
+
+
 class _HTTPConflictException(HTTPException):
     """Request conflict with the current state of the target resource."""
 

--- a/src/starlite_saqlalchemy/health.py
+++ b/src/starlite_saqlalchemy/health.py
@@ -59,6 +59,16 @@ class AbstractHealthCheck(ABC):
         """
 
 
+class AppHealthCheck(AbstractHealthCheck):
+    """Simple health check that does not require any dependencies."""
+
+    name = "app"
+
+    async def ready(self) -> bool:
+        """Readiness check used when no other health check is available."""
+        return True
+
+
 class HealthResource(BaseModel):
     """Health data returned by the health endpoint."""
 

--- a/src/starlite_saqlalchemy/health.py
+++ b/src/starlite_saqlalchemy/health.py
@@ -5,13 +5,13 @@ Returns the app settings as details if successful, otherwise a 503.
 from __future__ import annotations
 
 import contextlib
+from enum import Enum
+from typing import Protocol
 
-from sqlalchemy.ext.asyncio import AsyncSession
-from starlite import get
+from starlite import Controller, get
 from starlite.exceptions import ServiceUnavailableException
 
 from starlite_saqlalchemy import settings
-from starlite_saqlalchemy.repository.sqlalchemy import SQLAlchemyRepository
 from starlite_saqlalchemy.settings import AppSettings
 
 
@@ -19,10 +19,56 @@ class HealthCheckFailure(ServiceUnavailableException):
     """Raise for health check failure."""
 
 
-@get(path=settings.api.HEALTH_PATH, tags=["Misc"])
-async def health_check(db_session: AsyncSession) -> AppSettings:
-    """Check database available and returns app config info."""
-    with contextlib.suppress(Exception):
-        if await SQLAlchemyRepository.check_health(db_session):
+class Health(Enum):
+    """Health check types."""
+
+    LIVE = "live"
+    READY = "ready"
+
+
+class HealthCheckProtocol(Protocol):
+    """Base protocol for implementing health checks."""
+
+    async def live(self) -> bool:
+        """Run a liveness check.
+
+        Returns:
+            True if the service is running, False otherwise
+        """
+
+    async def ready(self) -> bool:
+        """Run readiness check.
+
+        Returns:
+            True if the service is ready to serve requests, False otherwise
+        """
+
+    def error(self, target_health: Health) -> str:
+        """Error message to return when health check fails.
+
+        Args:
+            target_health: Type of health check that failed
+
+        Returns:
+            A string describing the failure state
+        """
+        if settings.app.DEBUG:
+            return f"Health check failed: {self.__class__.__name__}.{target_health.value}."
+        return f"App is not {target_health.value}."
+
+
+class HealthController(Controller):
+    """Holds health endpoints."""
+
+    health_checks: list[HealthCheckProtocol] = []
+
+    @get(path=settings.api.HEALTH_PATH, tags=["Misc"], raises=[HealthCheckFailure])
+    async def health_check(self) -> AppSettings:
+        """Run registered health checks."""
+        for health_check in self.health_checks:
+            with contextlib.suppress(Exception):
+                if await health_check.ready():
+                    continue
+            raise HealthCheckFailure(health_check.error(Health.READY))
+        else:
             return settings.app
-    raise HealthCheckFailure("DB not ready.")

--- a/src/starlite_saqlalchemy/health.py
+++ b/src/starlite_saqlalchemy/health.py
@@ -40,7 +40,7 @@ class HealthCheckFailure(ServiceUnavailableException):
 class AbstractHealthCheck(ABC):
     """Base protocol for implementing health checks."""
 
-    name: str = None
+    name: str = ""
 
     async def live(self) -> bool:
         """Run a liveness check.
@@ -89,7 +89,7 @@ class HealthController(Controller):
         for health_check in self.health_checks:
             try:
                 health[health_check.name] = await health_check.ready()
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 health[health_check.name] = False
         if not all(health.values()):
             raise HealthCheckFailure(health=health)

--- a/src/starlite_saqlalchemy/health.py
+++ b/src/starlite_saqlalchemy/health.py
@@ -4,30 +4,43 @@ Returns the app settings as details if successful, otherwise a 503.
 """
 from __future__ import annotations
 
-import contextlib
-from enum import Enum
-from typing import Protocol
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from starlite import Controller, get
+from pydantic import BaseModel
+from starlite import Controller, Response, get
 from starlite.exceptions import ServiceUnavailableException
 
 from starlite_saqlalchemy import settings
 from starlite_saqlalchemy.settings import AppSettings
 
+if TYPE_CHECKING:
+    from typing import Any
+
+    from starlite import Request
+
 
 class HealthCheckFailure(ServiceUnavailableException):
     """Raise for health check failure."""
 
+    def __init__(
+        self,
+        health: dict[str, bool],
+        *args: Any,
+        detail: str = "",
+        status_code: int | None = None,
+        headers: dict[str, str] | None = None,
+        extra: dict[str, Any] | list[Any] | None = None,
+    ) -> None:
+        """Initialize HealthCheckFailure with an additional health arg."""
+        super().__init__(*args, detail, status_code, headers, extra)
+        self.health = health
 
-class Health(Enum):
-    """Health check types."""
 
-    LIVE = "live"
-    READY = "ready"
-
-
-class HealthCheckProtocol(Protocol):
+class AbstractHealthCheck(ABC):
     """Base protocol for implementing health checks."""
+
+    name: str = None
 
     async def live(self) -> bool:
         """Run a liveness check.
@@ -35,7 +48,9 @@ class HealthCheckProtocol(Protocol):
         Returns:
             True if the service is running, False otherwise
         """
+        return await self.ready()  # pragma: no cover
 
+    @abstractmethod
     async def ready(self) -> bool:
         """Run readiness check.
 
@@ -43,32 +58,39 @@ class HealthCheckProtocol(Protocol):
             True if the service is ready to serve requests, False otherwise
         """
 
-    def error(self, target_health: Health) -> str:
-        """Error message to return when health check fails.
 
-        Args:
-            target_health: Type of health check that failed
+class HealthResource(BaseModel):
+    """Health data returned by the health endpoint."""
 
-        Returns:
-            A string describing the failure state
-        """
-        if settings.app.DEBUG:
-            return f"Health check failed: {self.__class__.__name__}.{target_health.value}."
-        return f"App is not {target_health.value}."
+    app: AppSettings
+    health: dict[str, bool]
+
+
+def health_failure_exception_handler(
+    _: Request, exc: HealthCheckFailure
+) -> Response[HealthResource]:
+    """Return all health checks data on `HealthCheckFailure`."""
+    return Response(
+        status_code=HealthCheckFailure.status_code,
+        content=HealthResource(app=settings.app, health=exc.health),
+    )
 
 
 class HealthController(Controller):
     """Holds health endpoints."""
 
-    health_checks: list[HealthCheckProtocol] = []
+    exception_handlers = {HealthCheckFailure: health_failure_exception_handler}
+    health_checks: list[AbstractHealthCheck] = []
 
     @get(path=settings.api.HEALTH_PATH, tags=["Misc"], raises=[HealthCheckFailure])
-    async def health_check(self) -> AppSettings:
+    async def health_check(self) -> HealthResource:
         """Run registered health checks."""
+        health: dict[str, bool] = {}
         for health_check in self.health_checks:
-            with contextlib.suppress(Exception):
-                if await health_check.ready():
-                    continue
-            raise HealthCheckFailure(health_check.error(Health.READY))
-        else:
-            return settings.app
+            try:
+                health[health_check.name] = await health_check.ready()
+            except Exception:
+                health[health_check.name] = False
+        if not all(health.values()):
+            raise HealthCheckFailure(health=health)
+        return HealthResource(app=settings.app, health=health)

--- a/src/starlite_saqlalchemy/init_plugin.py
+++ b/src/starlite_saqlalchemy/init_plugin.py
@@ -52,7 +52,11 @@ from starlite_saqlalchemy import (
     sqlalchemy_plugin,
 )
 from starlite_saqlalchemy.exceptions import HealthCheckConfigurationError
-from starlite_saqlalchemy.health import AbstractHealthCheck, HealthController
+from starlite_saqlalchemy.health import (
+    AbstractHealthCheck,
+    AppHealthCheck,
+    HealthController,
+)
 from starlite_saqlalchemy.service import make_service_callback
 from starlite_saqlalchemy.sqlalchemy_plugin import SQLAlchemyHealthCheck
 from starlite_saqlalchemy.type_encoders import type_encoders_map
@@ -163,7 +167,7 @@ class PluginConfig(BaseModel):
     """Chain of structlog log processors."""
     type_encoders: TypeEncodersMap = type_encoders_map
     """Map of type to serializer callable."""
-    health_checks: Sequence[type[AbstractHealthCheck]] = [SQLAlchemyHealthCheck]
+    health_checks: Sequence[type[AbstractHealthCheck]] = [AppHealthCheck, SQLAlchemyHealthCheck]
 
 
 class ConfigureApp:

--- a/src/starlite_saqlalchemy/settings.py
+++ b/src/starlite_saqlalchemy/settings.py
@@ -135,7 +135,7 @@ class LogSettings(BaseSettings):
     SAQ_LEVEL: int = 30
     """Level to log SAQ logs."""
     SQLALCHEMY_LEVEL: int = 30
-    """Level to log SAQ logs."""
+    """Level to log SQLAlchemy logs."""
     UVICORN_ACCESS_LEVEL: int = 30
     """Level to log uvicorn access logs."""
     UVICORN_ERROR_LEVEL: int = 20

--- a/src/starlite_saqlalchemy/sqlalchemy_plugin.py
+++ b/src/starlite_saqlalchemy/sqlalchemy_plugin.py
@@ -65,9 +65,6 @@ class SQLAlchemyHealthCheck(AbstractHealthCheck):
                 await session.execute(text("SELECT 1"))
             ).scalar_one() == 1
 
-    # def error(self, health: Health) -> str:
-    #     return f"DB not {health.value}."
-
 
 config = SQLAlchemyConfig(
     before_send_handler=before_send_handler,

--- a/src/starlite_saqlalchemy/sqlalchemy_plugin.py
+++ b/src/starlite_saqlalchemy/sqlalchemy_plugin.py
@@ -12,7 +12,7 @@ from starlite.plugins.sql_alchemy.config import (
 )
 
 from starlite_saqlalchemy import db, settings
-from starlite_saqlalchemy.health import Health, HealthCheckProtocol
+from starlite_saqlalchemy.health import AbstractHealthCheck
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -43,7 +43,9 @@ async def before_send_handler(message: "Message", _: "State", scope: "Scope") ->
             del scope[SESSION_SCOPE_KEY]  # type:ignore[misc]
 
 
-class SQLAlchemyHealthCheck(HealthCheckProtocol):
+class SQLAlchemyHealthCheck(AbstractHealthCheck):
+    name: str = "db"
+
     def __init__(self) -> None:
         self.engine = create_async_engine(
             settings.db.URL, logging_name="starlite_saqlalchemy.health"
@@ -60,8 +62,8 @@ class SQLAlchemyHealthCheck(HealthCheckProtocol):
             await self.session.execute(text("SELECT 1"))
         ).scalar_one() == 1
 
-    def error(self, health: Health) -> str:
-        return f"DB not {health.value}."
+    # def error(self, health: Health) -> str:
+    #     return f"DB not {health.value}."
 
 
 config = SQLAlchemyConfig(

--- a/src/starlite_saqlalchemy/sqlalchemy_plugin.py
+++ b/src/starlite_saqlalchemy/sqlalchemy_plugin.py
@@ -45,7 +45,9 @@ async def before_send_handler(message: "Message", _: "State", scope: "Scope") ->
 
 class SQLAlchemyHealthCheck(HealthCheckProtocol):
     def __init__(self) -> None:
-        self.engine = create_async_engine(settings.db.URL, logging_name="health")
+        self.engine = create_async_engine(
+            settings.db.URL, logging_name="starlite_saqlalchemy.health"
+        )
         self.session = async_sessionmaker(bind=self.engine)
 
     async def ready(self) -> bool:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -2,10 +2,13 @@
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
+import pytest
 from starlite.status_codes import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 
 from starlite_saqlalchemy import settings
-from starlite_saqlalchemy.repository.sqlalchemy import SQLAlchemyRepository
+from starlite_saqlalchemy.health import Health, HealthCheckProtocol, HealthController
+from starlite_saqlalchemy.sqlalchemy_plugin import SQLAlchemyHealthCheck
+from starlite_saqlalchemy.testing import modify_settings
 
 if TYPE_CHECKING:
     from pytest import MonkeyPatch
@@ -18,7 +21,7 @@ def test_health_check(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
     Checks that we call the repository method and the response content.
     """
     repo_health_mock = AsyncMock()
-    monkeypatch.setattr(SQLAlchemyRepository, "check_health", repo_health_mock)
+    monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_200_OK
     assert resp.json() == settings.app.dict()
@@ -28,7 +31,7 @@ def test_health_check(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
 def test_health_check_false_response(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
     """Test health check response if check method returns `False`"""
     repo_health_mock = AsyncMock(return_value=False)
-    monkeypatch.setattr(SQLAlchemyRepository, "check_health", repo_health_mock)
+    monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
 
@@ -36,6 +39,46 @@ def test_health_check_false_response(client: "TestClient", monkeypatch: "MonkeyP
 def test_health_check_exception_raised(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
     """Test expected response from check if exception raised in handler."""
     repo_health_mock = AsyncMock(side_effect=ConnectionError)
-    monkeypatch.setattr(SQLAlchemyRepository, "check_health", repo_health_mock)
+    monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
+
+
+def test_health_custom_health_check(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
+    """Test registering custom health checks."""
+
+    class MyHealthCheck(HealthCheckProtocol):
+        async def ready(self) -> bool:
+            return False
+
+        def error(self, _: Health) -> str:
+            return "That's weird."
+
+    HealthController.health_checks.append(MyHealthCheck())
+    repo_health_mock = AsyncMock()
+    monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
+    resp = client.get(settings.api.HEALTH_PATH)
+    assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
+    assert resp.json() == {"status_code": 503, "detail": "That's weird."}
+
+
+@pytest.mark.parametrize(
+    ("debug", "expected_error"),
+    [(True, "Health check failed: MyHealthCheck.ready."), (False, "App is not ready.")],
+)
+def test_health_default_error(
+    client: "TestClient", monkeypatch: "MonkeyPatch", debug: bool, expected_error: str
+) -> None:
+    """Test registering custom health checks."""
+
+    class MyHealthCheck(HealthCheckProtocol):
+        async def ready(self) -> bool:
+            return False
+
+    with modify_settings((settings.app, {"DEBUG": debug})):
+        HealthController.health_checks.append(MyHealthCheck())
+        repo_health_mock = AsyncMock()
+        monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
+        resp = client.get(settings.api.HEALTH_PATH)
+        assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
+        assert resp.json() == {"status_code": 503, "detail": expected_error}

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -31,7 +31,7 @@ def test_health_check(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_200_OK
     health = HealthResource(
-        app=settings.app.dict(),
+        app=settings.app,
         health={SQLAlchemyHealthCheck.name: True, AppHealthCheck.name: True},
     )
     assert resp.json() == health.dict()
@@ -45,7 +45,7 @@ def test_health_check_false_response(client: "TestClient", monkeypatch: "MonkeyP
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
     health = HealthResource(
-        app=settings.app.dict(),
+        app=settings.app,
         health={SQLAlchemyHealthCheck.name: False, AppHealthCheck.name: True},
     )
     assert resp.json() == health.dict()
@@ -58,7 +58,7 @@ def test_health_check_exception_raised(client: "TestClient", monkeypatch: "Monke
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
     health = HealthResource(
-        app=settings.app.dict(),
+        app=settings.app,
         health={SQLAlchemyHealthCheck.name: False, AppHealthCheck.name: True},
     )
     assert resp.json() == health.dict()
@@ -82,7 +82,7 @@ def test_health_custom_health_check(client: "TestClient", monkeypatch: "MonkeyPa
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
     health = HealthResource(
-        app=settings.app.dict(),
+        app=settings.app,
         health={
             AppHealthCheck.name: True,
             SQLAlchemyHealthCheck.name: True,

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -3,12 +3,17 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
+from starlite import Starlite
 from starlite.status_codes import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 
-from starlite_saqlalchemy import settings
-from starlite_saqlalchemy.health import Health, HealthCheckProtocol, HealthController
+from starlite_saqlalchemy import init_plugin, settings
+from starlite_saqlalchemy.exceptions import HealthCheckConfigurationError
+from starlite_saqlalchemy.health import (
+    AbstractHealthCheck,
+    HealthController,
+    HealthResource,
+)
 from starlite_saqlalchemy.sqlalchemy_plugin import SQLAlchemyHealthCheck
-from starlite_saqlalchemy.testing import modify_settings
 
 if TYPE_CHECKING:
     from pytest import MonkeyPatch
@@ -20,11 +25,14 @@ def test_health_check(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
 
     Checks that we call the repository method and the response content.
     """
-    repo_health_mock = AsyncMock()
+    repo_health_mock = AsyncMock(return_value=True)
     monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_200_OK
-    assert resp.json() == settings.app.dict()
+    assert (
+        resp.json()
+        == HealthResource(app=settings.app.dict(), health={SQLAlchemyHealthCheck.name: True}).dict()
+    )
     repo_health_mock.assert_called_once()
 
 
@@ -34,6 +42,12 @@ def test_health_check_false_response(client: "TestClient", monkeypatch: "MonkeyP
     monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
+    assert (
+        resp.json()
+        == HealthResource(
+            app=settings.app.dict(), health={SQLAlchemyHealthCheck.name: False}
+        ).dict()
+    )
 
 
 def test_health_check_exception_raised(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
@@ -42,43 +56,66 @@ def test_health_check_exception_raised(client: "TestClient", monkeypatch: "Monke
     monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
+    assert (
+        resp.json()
+        == HealthResource(
+            app=settings.app.dict(), health={SQLAlchemyHealthCheck.name: False}
+        ).dict()
+    )
 
 
 def test_health_custom_health_check(client: "TestClient", monkeypatch: "MonkeyPatch") -> None:
     """Test registering custom health checks."""
 
-    class MyHealthCheck(HealthCheckProtocol):
+    class MyHealthCheck(AbstractHealthCheck):
+        name = "MyHealthCheck"
+
         async def ready(self) -> bool:
             return False
 
-        def error(self, _: Health) -> str:
-            return "That's weird."
-
     HealthController.health_checks.append(MyHealthCheck())
-    repo_health_mock = AsyncMock()
+    repo_health_mock = AsyncMock(return_value=True)
     monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
     resp = client.get(settings.api.HEALTH_PATH)
     assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
-    assert resp.json() == {"status_code": 503, "detail": "That's weird."}
+    assert (
+        resp.json()
+        == HealthResource(
+            app=settings.app.dict(),
+            health={SQLAlchemyHealthCheck.name: True, MyHealthCheck.name: False},
+        ).dict()
+    )
 
 
-@pytest.mark.parametrize(
-    ("debug", "expected_error"),
-    [(True, "Health check failed: MyHealthCheck.ready."), (False, "App is not ready.")],
-)
-def test_health_default_error(
-    client: "TestClient", monkeypatch: "MonkeyPatch", debug: bool, expected_error: str
-) -> None:
-    """Test registering custom health checks."""
-
-    class MyHealthCheck(HealthCheckProtocol):
+def test_health_check_no_name_error(client: "TestClient") -> None:
+    class MyHealthCheck(AbstractHealthCheck):
         async def ready(self) -> bool:
             return False
 
-    with modify_settings((settings.app, {"DEBUG": debug})):
-        HealthController.health_checks.append(MyHealthCheck())
-        repo_health_mock = AsyncMock()
-        monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
-        resp = client.get(settings.api.HEALTH_PATH)
-        assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
-        assert resp.json() == {"status_code": 503, "detail": expected_error}
+    config = init_plugin.PluginConfig(health_checks=[MyHealthCheck])
+    with pytest.raises(HealthCheckConfigurationError):
+        Starlite(route_handlers=[], on_app_init=[init_plugin.ConfigureApp(config=config)])
+
+
+# @pytest.mark.parametrize(
+#     ("debug", "expected_error"),
+#     [(True, "Health check failed: MyHealthCheck.ready."), (False, "App is not ready.")],
+# )
+# def test_health_default_error(
+#     client: "TestClient", monkeypatch: "MonkeyPatch", debug: bool, expected_error: str
+# ) -> None:
+#     """Test registering custom health checks."""
+
+#     class MyHealthCheck(HealthCheckProtocol):
+#         name = "MyHealthCheck"
+
+#         async def ready(self) -> bool:
+#             return False
+
+#     with modify_settings((settings.app, {"DEBUG": debug})):
+#         HealthController.health_checks.append(MyHealthCheck())
+#         repo_health_mock = AsyncMock(return_value=True)
+#         monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
+#         resp = client.get(settings.api.HEALTH_PATH)
+#         assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
+#         assert resp.json() == {"status_code": 503, "detail": expected_error}

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -68,9 +68,12 @@ def test_health_custom_health_check(client: "TestClient", monkeypatch: "MonkeyPa
     """Test registering custom health checks."""
 
     class MyHealthCheck(AbstractHealthCheck):
+        """Custom health check."""
+
         name = "MyHealthCheck"
 
         async def ready(self) -> bool:
+            """Readiness check."""
             return False
 
     HealthController.health_checks.append(MyHealthCheck())
@@ -87,35 +90,17 @@ def test_health_custom_health_check(client: "TestClient", monkeypatch: "MonkeyPa
     )
 
 
-def test_health_check_no_name_error(client: "TestClient") -> None:
+def test_health_check_no_name_error() -> None:
+    """Test registering an health check without specifying its name raise an
+    error."""
+
     class MyHealthCheck(AbstractHealthCheck):
+        """Custom health check."""
+
         async def ready(self) -> bool:
+            """Readiness check."""
             return False
 
     config = init_plugin.PluginConfig(health_checks=[MyHealthCheck])
     with pytest.raises(HealthCheckConfigurationError):
         Starlite(route_handlers=[], on_app_init=[init_plugin.ConfigureApp(config=config)])
-
-
-# @pytest.mark.parametrize(
-#     ("debug", "expected_error"),
-#     [(True, "Health check failed: MyHealthCheck.ready."), (False, "App is not ready.")],
-# )
-# def test_health_default_error(
-#     client: "TestClient", monkeypatch: "MonkeyPatch", debug: bool, expected_error: str
-# ) -> None:
-#     """Test registering custom health checks."""
-
-#     class MyHealthCheck(HealthCheckProtocol):
-#         name = "MyHealthCheck"
-
-#         async def ready(self) -> bool:
-#             return False
-
-#     with modify_settings((settings.app, {"DEBUG": debug})):
-#         HealthController.health_checks.append(MyHealthCheck())
-#         repo_health_mock = AsyncMock(return_value=True)
-#         monkeypatch.setattr(SQLAlchemyHealthCheck, "ready", repo_health_mock)
-#         resp = client.get(settings.api.HEALTH_PATH)
-#         assert resp.status_code == HTTP_503_SERVICE_UNAVAILABLE
-#         assert resp.json() == {"status_code": 503, "detail": expected_error}


### PR DESCRIPTION
Closes #174 

It also brings `AbstractHealthCheck` to register custom health checks:

```python
class MyHealthCheck(AbstractHealthCheck):
    name: str = "my_health_check"

    def ready(self) -> bool:
        return True

...

from starlite_saqlalchemy.sqlalchemy_plugin import SQLAlchemyHealthCheck
from starlite_saqlalchemy.health import AppHealthCheck

config = init_plugin.PluginConfig(health_checks=[AppHealthCheck, SQLAlchemyHealthCheck, MyHealthCheck])
Starlite(route_handlers=[], on_app_init=[init_plugin.ConfigureApp(config=config)])
```

Calling the health endpoint now returns all health checks statuses:

```json
{
  "app": {
    "BUILD_NUMBER": "",
    "CHECK_DB_READY": true,
    "CHECK_REDIS_READY": true,
    "DEBUG": false,
    "ENVIRONMENT": "prod",
    "NAME": "my-starlite-saqlalchemy-app"
  },
  "health": {
    "app": true,
    "db": true,
    "my_health_check": true
  }
}
``` 

This would would also help getting #213 merged since we could easily disable `SQLAlchemyHealthCheck` if sqlalchemy is not installed.