### PR TITLE
feat: makes the `created/updated` indicators on ORM models optional.

### DIFF
--- a/src/starlite_saqlalchemy/testing/generic_mock_repository.py
+++ b/src/starlite_saqlalchemy/testing/generic_mock_repository.py
@@ -62,7 +62,8 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
         if allow_id is False and self.get_id_attribute_value(data) is not None:
             raise ConflictError("`add()` received identified item.")
         now = datetime.now()
-        data.updated = data.created = now
+        if hasattr(data, "updated") and hasattr(data, "created"):
+            data.updated = data.created = now  # type: ignore[attr-defined]
         if allow_id is False:
             id_ = self._id_factory()
             self.set_id_attribute_value(id_, data)
@@ -127,7 +128,8 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
         """
         item = self._find_or_raise_not_found(self.get_id_attribute_value(data))
         # should never be modifiable
-        data.updated = datetime.now()
+        if hasattr(data, "updated"):
+            data.updated = datetime.now()  # type: ignore[attr-defined]
         for key, val in data.__dict__.items():
             if key.startswith("_"):
                 continue

--- a/src/starlite_saqlalchemy/testing/generic_mock_repository.py
+++ b/src/starlite_saqlalchemy/testing/generic_mock_repository.py
@@ -63,7 +63,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
             raise ConflictError("`add()` received identified item.")
         now = datetime.now()
         if hasattr(data, "updated") and hasattr(data, "created"):
-            data.updated = data.created = now  # type: ignore[attr-defined]
+            data.updated = data.created = now
         if allow_id is False:
             id_ = self._id_factory()
             self.set_id_attribute_value(id_, data)
@@ -129,7 +129,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
         item = self._find_or_raise_not_found(self.get_id_attribute_value(data))
         # should never be modifiable
         if hasattr(data, "updated"):
-            data.updated = datetime.now()  # type: ignore[attr-defined]
+            data.updated = datetime.now()
         for key, val in data.__dict__.items():
             if key.startswith("_"):
                 continue

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -20,5 +20,5 @@ def test_worker_decoder_handles_pydantic_models(authors: list[Author]) -> None:
     encoded = worker.encoder.encode(pydantic_model)
     assert (
         encoded
-        == b'{"id":"97108ac1-ffcb-411d-8b1e-d9183399f63b","created":"0001-01-01T00:00:00","updated":"0001-01-01T00:00:00","name":"Agatha Christie","dob":"1890-09-15"}'
+        == b'{"created":"0001-01-01T00:00:00","updated":"0001-01-01T00:00:00","id":"97108ac1-ffcb-411d-8b1e-d9183399f63b","name":"Agatha Christie","dob":"1890-09-15"}'
     )

--- a/tests/utils/domain/authors.py
+++ b/tests/utils/domain/authors.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Mapped
 from starlite_saqlalchemy import db, dto, repository, service
 
 
-class Author(db.orm.Base):
+class Author(db.orm.Base, db.orm.CreatedUpdatedMixin):
     """The Author domain object."""
 
     name: Mapped[str]


### PR DESCRIPTION
I'd like to be able to optionally include the 2 audit columns on base models.  

This enhancements moves the created/updated into a mixin and updates the test cases accordingly.  

If you are OK with something like this, I'll make updates to the documentation next.