### PR TITLE
feat: implements count method and pagination with total

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       - id: docformatter
         args: [--in-place]
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.2.3
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         exclude: "test*|examples*"

--- a/src/starlite_saqlalchemy/repository/abc.py
+++ b/src/starlite_saqlalchemy/repository/abc.py
@@ -53,13 +53,8 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def count(self, *filters: FilterTypes, **kwargs: Any) -> int:
-        """Get the count of records returned by a query.  Optionally filtered.
-
-
-        Args:
-            *filters: Types for specific filtering operations.
-            **kwargs: Instance attribute value filters.
+    async def count(self, select_: Any | None = None) -> int:
+        """Get the count of records returned by a query.
 
         Returns:
             The count of instances
@@ -80,7 +75,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def list(self, *filters: FilterTypes, **kwargs: Any) -> list[T]:
+    async def list(self, *filters: FilterTypes, **kwargs: Any) -> tuple[list[T], int]:
         """Get a list of instances, optionally filtered.
 
         Args:

--- a/src/starlite_saqlalchemy/repository/abc.py
+++ b/src/starlite_saqlalchemy/repository/abc.py
@@ -56,6 +56,9 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
     async def count(self, select_: Any | None = None) -> int:
         """Get the count of records returned by a query.
 
+        Args:
+            select_: Optional statement to use for counting.
+
         Returns:
             The count of instances
         """

--- a/src/starlite_saqlalchemy/repository/abc.py
+++ b/src/starlite_saqlalchemy/repository/abc.py
@@ -53,6 +53,19 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
         """
 
     @abstractmethod
+    async def count(self, *filters: FilterTypes, **kwargs: Any) -> int:
+        """Get the count of records returned by a query.  Optionally filtered.
+
+
+        Args:
+            *filters: Types for specific filtering operations.
+            **kwargs: Instance attribute value filters.
+
+        Returns:
+            The count of instances
+        """
+
+    @abstractmethod
     async def get(self, id_: Any) -> T:
         """Get instance identified by `id_`.
 

--- a/src/starlite_saqlalchemy/repository/sqlalchemy.py
+++ b/src/starlite_saqlalchemy/repository/sqlalchemy.py
@@ -139,7 +139,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
         """
         count_query = self._select
         for filter_ in filters:
-            match filter_:  # noqa: E999
+            match filter_:
                 case LimitOffset(limit, offset):
                     self._apply_limit_offset_pagination(limit, offset)
                     # we do not apply this filter to the count since we need the total rows

--- a/src/starlite_saqlalchemy/service/generic.py
+++ b/src/starlite_saqlalchemy/service/generic.py
@@ -53,7 +53,7 @@ class Service(Generic[T]):
         """
         return data
 
-    async def list(self, **kwargs: Any) -> list[T]:
+    async def list(self, **kwargs: Any) -> tuple[list[T], int]:
         """Return view of the collection of `T`.
 
         Args:
@@ -62,7 +62,7 @@ class Service(Generic[T]):
         Returns:
             The list of instances retrieved from the repository.
         """
-        return []
+        return [], 0
 
     async def update(self, id_: Any, data: T) -> T:
         """Update existing instance of `T` with `data`.

--- a/src/starlite_saqlalchemy/service/sqlalchemy.py
+++ b/src/starlite_saqlalchemy/service/sqlalchemy.py
@@ -50,7 +50,7 @@ class RepositoryService(Service[ModelT], Generic[ModelT]):
         """
         return await self.repository.add(data)
 
-    async def list(self, *filters: "FilterTypes", **kwargs: Any) -> list[ModelT]:
+    async def list(self, *filters: "FilterTypes", **kwargs: Any) -> tuple[list[ModelT], int]:
         """Wrap repository scalars operation.
 
         Args:
@@ -122,24 +122,3 @@ class RepositoryService(Service[ModelT], Generic[ModelT]):
         """
         async with async_session_factory() as session:
             yield cls(session=session)
-
-
-class PaginatedRepositoryService(RepositoryService):
-    """Paginated Service object that operates on a repository object."""
-
-    __id__ = "starlite_saqlalchemy.service.sqlalchemy.PaginatedRepositoryService"
-
-    async def list(self, *filters: "FilterTypes", **kwargs: Any) -> tuple[list[ModelT], int]:
-        """Wrap repository scalars operation.
-
-        Args:
-            *filters: Collection route filters.
-            **kwargs: Keyword arguments for attribute based filtering.
-
-        Returns:
-            The list of instances retrieved from the repository.
-        """
-        return (
-            await self.repository.list(*filters, **kwargs),
-            await self.repository.count(*filters, **kwargs),
-        )

--- a/src/starlite_saqlalchemy/service/sqlalchemy.py
+++ b/src/starlite_saqlalchemy/service/sqlalchemy.py
@@ -122,3 +122,24 @@ class RepositoryService(Service[ModelT], Generic[ModelT]):
         """
         async with async_session_factory() as session:
             yield cls(session=session)
+
+
+class PaginatedRepositoryService(RepositoryService):
+    """Paginated Service object that operates on a repository object."""
+
+    __id__ = "starlite_saqlalchemy.service.sqlalchemy.PaginatedRepositoryService"
+
+    async def list(self, *filters: "FilterTypes", **kwargs: Any) -> tuple[list[ModelT], int]:
+        """Wrap repository scalars operation.
+
+        Args:
+            *filters: Collection route filters.
+            **kwargs: Keyword arguments for attribute based filtering.
+
+        Returns:
+            The list of instances retrieved from the repository.
+        """
+        return (
+            await self.repository.list(*filters, **kwargs),
+            await self.repository.count(*filters, **kwargs),
+        )

--- a/src/starlite_saqlalchemy/testing/generic_mock_repository.py
+++ b/src/starlite_saqlalchemy/testing/generic_mock_repository.py
@@ -102,7 +102,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
         """
         return self._find_or_raise_not_found(id_)
 
-    async def list(self, *filters: "FilterTypes", **kwargs: Any) -> list[ModelT]:
+    async def list(self, *filters: "FilterTypes", **kwargs: Any) -> tuple[list[ModelT], int]:
         """Get a list of instances, optionally filtered.
 
         Args:
@@ -112,7 +112,19 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
         Returns:
             The list of instances, after filtering applied.
         """
-        return list(self.collection.values())
+        return list(self.collection.values()), len(list(self.collection.values()))
+
+    async def count(self, select_: Any | None = None) -> int:
+        """Get a list of instances, optionally filtered.
+
+        Args:
+            *filters: Types for specific filtering operations.
+            **kwargs: Instance attribute value filters.
+
+        Returns:
+            The list of instances, after filtering applied.
+        """
+        return len(list(self.collection.values()))
 
     async def update(self, data: ModelT) -> ModelT:
         """Update instance with the attribute values present on `data`.

--- a/tests/unit/require_sqlalchemy/repository/test_sqlalchemy.py
+++ b/tests/unit/require_sqlalchemy/repository/test_sqlalchemy.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
-from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest

--- a/tests/unit/require_sqlalchemy/repository/test_sqlalchemy.py
+++ b/tests/unit/require_sqlalchemy/repository/test_sqlalchemy.py
@@ -119,6 +119,19 @@ async def test_sqlalchemy_repo_list_with_pagination(
     mock_repo._select.limit().offset.assert_called_once_with(3)  # type:ignore[call-arg]
 
 
+async def test_sqlalchemy_repo_count(
+    mock_repo: SQLAlchemyRepository, monkeypatch: MonkeyPatch
+) -> None:
+    """Test count operation with pagination."""
+    mock_instances = [MagicMock(), MagicMock()]
+    result_mock = MagicMock()
+    result_mock.scalars = MagicMock(len(mock_instances))
+    execute_mock = AsyncMock(return_value=result_mock)
+    monkeypatch.setattr(mock_repo, "_execute", execute_mock)
+    instance_count = await mock_repo.count()
+    assert instance_count == len(mock_instances)
+
+
 async def test_sqlalchemy_repo_list_with_before_after_filter(
     mock_repo: SQLAlchemyRepository, monkeypatch: MonkeyPatch
 ) -> None:

--- a/tests/unit/require_sqlalchemy/test_service.py
+++ b/tests/unit/require_sqlalchemy/test_service.py
@@ -36,14 +36,16 @@ async def test_service_create() -> None:
 
 async def test_service_list() -> None:
     """Test repository list action."""
-    resp = await domain.authors.Service().list()
-    assert len(resp) == 2
+    items, count = await domain.authors.Service().list()
+    assert isinstance(items, list)
+    assert count == 2
 
 
 async def test_service_update() -> None:
     """Test repository update action."""
     service_obj = domain.authors.Service()
-    author, _ = await service_obj.list()
+    authors, _ = await service_obj.list()
+    author = authors[0]
     assert author.name == "Agatha Christie"
     author.name = "different"
     resp = await service_obj.update(author.id, author)
@@ -53,7 +55,8 @@ async def test_service_update() -> None:
 async def test_service_upsert_update() -> None:
     """Test repository upsert action for update."""
     service_obj = domain.authors.Service()
-    author, _ = await service_obj.list()
+    authors, _ = await service_obj.list()
+    author = authors[0]
     assert author.name == "Agatha Christie"
     author.name = "different"
     resp = await service_obj.upsert(author.id, author)
@@ -72,7 +75,8 @@ async def test_service_upsert_create() -> None:
 async def test_service_get() -> None:
     """Test repository get action."""
     service_obj = domain.authors.Service()
-    author, _ = await service_obj.list()
+    authors, _ = await service_obj.list()
+    author = authors[0]
     retrieved = await service_obj.get(author.id)
     assert author is retrieved
 
@@ -80,7 +84,8 @@ async def test_service_get() -> None:
 async def test_service_delete() -> None:
     """Test repository delete action."""
     service_obj = domain.authors.Service()
-    author, _ = await service_obj.list()
+    authors, _ = await service_obj.list()
+    author = authors[0]
     deleted = await service_obj.delete(author.id)
     assert author is deleted
 
@@ -96,7 +101,7 @@ async def test_service_method_default_behavior() -> None:
     service_obj = service.Service[object]()
     data = object()
     assert await service_obj.create(data) is data
-    assert await service_obj.list() == []
+    assert await service_obj.list() == ([], 0)
     assert await service_obj.update("abc", data) is data
     assert await service_obj.upsert("abc", data) is data
     with pytest.raises(NotFoundError):


### PR DESCRIPTION
This enhancements currently adds an `count` method to the `AbstractRepository` and `SQLAlchemyRepository` classes.  

It also implements another `PaginatedSQLAlchemyRepository` class that implements a `list` method returning a `tuple[list[ModelT], int]` instead of `list[ModelT]`.  This allows for easy integration with the Limit/Offset Pagination within Starlite.

I'm still trying to wrap my head around how the testing works, so it's lacking a bit there.

I've opened this PR up even though it's not quite ready so you can weigh in.  Let me know if you think there's a better way to implement this or it's something you aren't looking to include here.
