### PR TITLE
feat(sentry): override traces sampler

### DIFF
--- a/src/starlite_saqlalchemy/init_plugin.py
+++ b/src/starlite_saqlalchemy/init_plugin.py
@@ -104,7 +104,7 @@ class PluginConfig(BaseModel):
     Add configuration for gzip compression to
     [`AppConfig.compression_config`][starlite.config.app.AppConfig.compression_config].
     """
-    do_collection_dependencies = True
+    do_collection_dependencies: bool = True
     """Add collection route dependencies.
 
     Add the [`Provide`][starlite.datastructures.Provide]'s for collection route dependencies to

--- a/src/starlite_saqlalchemy/init_plugin.py
+++ b/src/starlite_saqlalchemy/init_plugin.py
@@ -143,6 +143,8 @@ class PluginConfig(BaseModel):
     Configure the application to initialize Sentry on startup. Adds a handler to
     [`AppConfig.on_startup`][starlite.config.app.AppConfig.on_startup].
     """
+    sentry_traces_sampler: Callable[[dict], float] | None = None
+    """Override sentry traces sampler."""
     do_set_debug: bool = True
     """Configure Starlite debug mode.
 
@@ -379,7 +381,7 @@ class ConfigureApp:
         if self.config.do_sentry:
             from starlite_saqlalchemy import sentry
 
-            sentry.configure()
+            sentry.configure(traces_sampler=self.config.sentry_traces_sampler)
 
     def configure_sqlalchemy_plugin(self, app_config: AppConfig) -> None:
         """Configure `SQLAlchemy` for the application.

--- a/src/starlite_saqlalchemy/sentry.py
+++ b/src/starlite_saqlalchemy/sentry.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from typing import Any
 
+    from sentry_sdk._types import TracesSampler
     from starlite.types import HTTPScope
 
 
@@ -32,7 +33,7 @@ def sentry_traces_sampler(sampling_context: Mapping[str, Any]) -> float:
     return settings.sentry.TRACES_SAMPLE_RATE
 
 
-def configure() -> None:
+def configure(traces_sampler: TracesSampler | None = None) -> None:
     """Configure sentry on app startup.
 
     See [SentrySettings][starlite_saqlalchemy.settings.SentrySettings].
@@ -42,5 +43,5 @@ def configure() -> None:
         environment=settings.app.ENVIRONMENT,
         release=settings.app.BUILD_NUMBER,
         integrations=[StarliteIntegration(), SqlalchemyIntegration()],
-        traces_sampler=sentry_traces_sampler,
+        traces_sampler=sentry_traces_sampler if traces_sampler is None else traces_sampler,
     )

--- a/tests/unit/require_no_extras/test_init_plugin_for_no_extras.py
+++ b/tests/unit/require_no_extras/test_init_plugin_for_no_extras.py
@@ -79,4 +79,4 @@ def test_extra_dependencies_not_installed(enabled_config: str, error_pattern: st
         **{enabled_config: True},
     }
     with pytest.raises(ValidationError, match=error_pattern):
-        init_plugin.PluginConfig(**kwargs)
+        init_plugin.PluginConfig(**kwargs)  # type:ignore[arg-type]

--- a/tests/unit/require_sqlalchemy/repository/test_sqlalchemy.py
+++ b/tests/unit/require_sqlalchemy/repository/test_sqlalchemy.py
@@ -239,7 +239,7 @@ def test_filter_collection_by_kwargs_raises_repository_exception_for_attribute_e
 ) -> None:
     """Test that we raise a repository exception if an attribute name is
     incorrect."""
-    mock_repo._select.filter_by = MagicMock(  # type:ignore[assignment]
+    mock_repo._select.filter_by = MagicMock(  # type:ignore[method-assign]
         side_effect=InvalidRequestError,
     )
     with pytest.raises(StarliteSaqlalchemyError):

--- a/tests/unit/test_init_plugin.py
+++ b/tests/unit/test_init_plugin.py
@@ -23,8 +23,7 @@ def test_config_switches() -> None:
         do_after_exception=False,
         do_cache=False,
         do_compression=False,
-        # pyright reckons this parameter doesn't exist, I beg to differ
-        do_collection_dependencies=False,  # pyright:ignore
+        do_collection_dependencies=False,
         do_exception_handlers=False,
         do_health_check=False,
         do_logging=False,


### PR DESCRIPTION
Add the ability to override sentry traces sampler.

Could be useful if path exclusion is more complex than just skipping health checks. 